### PR TITLE
fix: export match service (fixes #34)

### DIFF
--- a/osrm/lib/osrm.dart
+++ b/osrm/lib/osrm.dart
@@ -57,6 +57,7 @@ export 'src/builders.dart';
 // Services
 export 'src/services/nearest.dart';
 export 'src/services/route.dart';
+export 'src/services/match.dart';
 export 'src/shared/core.dart';
 export 'src/shared/models.dart';
 export 'src/shared/utils.dart';


### PR DESCRIPTION
In this pr I export the `services/match.dart`, which is missing from `osrm.dart` and can therefor not be accessed within other packages.

This pr closes #34 